### PR TITLE
feat: super basic test suite support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,130 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - main
+      - renovate/**
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          check-latest: true
+          node-version: lts/*
+      - run: corepack enable
+      - run: yarn install
+      - run: yarn build --sourcemap
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        with:
+          name: build-${{ github.sha }}
+          path: build
+
+  check:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+
+    name: Check
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          check-latest: true
+          node-version: lts/*
+      - run: corepack enable
+      - run: yarn install
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: build-${{ github.sha }}
+          path: build
+      - run: yarn check:spelling
+      - run: yarn check:types
+
+  quality:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+
+    name: Code Quality
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          check-latest: true
+          node-version: lts/*
+      - run: corepack enable
+      - run: yarn install
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: build-${{ github.sha }}
+          path: build
+      - run: yarn biome ci --error-on-warnings
+
+  test-node:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+
+    name: Test Build on Node.js v${{ matrix.node-version }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18.19', '18.x', '20.x', '22.x', '23.x']
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          check-latest: true
+          node-version: ${{ matrix.node-version }}
+      - run: corepack enable
+      - run: yarn install
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: build-${{ github.sha }}
+          path: build
+      - run: yarn test
+
+  test-os:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+
+    name: Test Build on ${{ matrix.os }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          check-latest: true
+          node-version: lts/*
+      - run: corepack enable
+      - run: yarn install
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: build-${{ github.sha }}
+          path: build
+      - run: yarn test

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,46 @@
+const console = require("node:console");
+const process = require("node:process");
+
+let showSpec = false;
+const args = process.argv.slice(2);
+/** @type {string[]} */
+const positionals = [];
+while (args.length > 0) {
+  const arg = args.shift() ?? "";
+  if (arg.startsWith("--")) {
+    if (arg.startsWith("--show-spec")) {
+      showSpec = true;
+    }
+    if (!arg.includes("=")) {
+      args.shift();
+    }
+  } else if (!arg.startsWith("-") && arg !== ".") {
+    positionals.push(arg);
+  }
+}
+let spec = [
+  // "**/*.test.js",
+  // "**/*.test.mjs",
+  // "**/*.test.cjs",
+  "**/*.test.ts",
+];
+if (positionals.length > 0) {
+  spec = positionals;
+}
+
+if (showSpec) {
+  console.log(`spec: ${JSON.stringify(spec)}`);
+}
+
+/**
+ * @type {{checkLeaks:boolean,ignore:string,loader?:string,"node-option"?:string[],recursive:boolean,spec:string[]}}
+ */
+const config = {
+  checkLeaks: true,
+  ignore: "node_modules/**/*",
+  "node-option": ["import=tsx", "import=source-map-support"],
+  recursive: true,
+  spec,
+};
+
+module.exports = config;

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
-    "ignore": [".cache/**", ".idea/**", ".yarn/**", "build/**", "coverage/**", "node_modules/**"]
+    "ignore": [".cache/**", ".idea/**", ".yarn/**", "build/**", "coverage/**", "node_modules/**"],
+    "ignoreUnknown": true
   },
   "formatter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -3,13 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "Run tstyche tests with a mocha-lookalike runner, allowing for IDE and mocha reporter integration",
-  "keywords": [
-    "typescript",
-    "test",
-    "runner",
-    "tstyche",
-    "mocha"
-  ],
+  "keywords": ["typescript", "test", "runner", "tstyche", "mocha"],
   "homepage": "https://tstyche.org",
   "bugs": {
     "url": "https://github.com/tstyche/tstyche-as-mocha/issues"
@@ -34,21 +28,29 @@
     "check:spelling": "cspell --config cspell.config.json --quiet",
     "check:types": "tsc --noEmit --project tsconfig.json",
     "clean": "rimraf build --preserve-root",
-    "format": "biome format --write",
+    "format": "biome format --write --verbose",
     "lint": "biome lint --write",
-    "prepublish": "yarn clean && yarn build",
-    "test": "echo '🚧 TODO: tests 🚧'"
+    "prepublish": "yarn build",
+    "test": "yarn test:mocha && yarn test:tstyche && yarn test:tstyche-as-mocha",
+    "test:mocha": "mocha",
+    "test:tstyche": "tstyche type-test",
+    "test:tstyche-as-mocha": "tsx ./source/mocha.ts --reporter ../test/test-reporter.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@types/chai": "5.0.1",
     "@types/mocha": "10.0.10",
     "@types/node": "22.10.5",
+    "chai": "5.1.2",
     "cpr": "3.0.1",
     "cspell": "8.17.1",
     "mkdirp": "3.0.1",
     "mocha": "11.0.1",
+    "mocha-reporter-gha": "1.1.1",
     "rimraf": "6.0.1",
+    "source-map-support": "0.5.21",
     "tstyche": "3.3.1",
+    "tsx": "4.19.2",
     "typescript": "5.7.2"
   },
   "packageManager": "yarn@4.6.0",

--- a/source/AsMochaReporter.ts
+++ b/source/AsMochaReporter.ts
@@ -1,0 +1,98 @@
+import * as console from "node:console";
+import * as process from "node:process";
+import type * as M from "mocha";
+import type { ResolvedConfig } from "tstyche/tstyche";
+import type { ReporterEvent } from "tstyche/tstyche";
+import { BaseReporter } from "tstyche/tstyche";
+
+export type LoadReporterOptions = {
+  reporter?: string;
+  verbose?: boolean;
+};
+
+export type RunnerHandler = (runner: M.Runner) => void;
+
+// noinspection JSUnusedGlobalSymbols
+export default class AsMochaReporter extends BaseReporter {
+  public static readonly CANNOT_FIND_ERROR: string = "Cannot find: --reporter or -R";
+
+  /**
+   * Find the path to the mocha (not TSTyche) reporter.  This may be a
+   * filesystem path, or it may be a package name.  This is *not* the
+   * path to `tstyche-as-mocha` — it is the path to the IDE's reporter
+   * UI script.
+   * @remarks
+   * For now, TSTyche doesn't have a concept of "Reporter options", and
+   * we don't really want to import all possible mocha CLI params into
+   * TSTyche param space.  Thus, we do a simple argv extraction.
+   * @privateRemarks
+   * Long term, maybe we add a TSTyche CLI param like `--reporter-config`
+   * or something.
+   * @example
+   * When configuring this in the IDE, this will look something like:
+   * ```
+   * --reporter /absolute/path/to/reporter.js
+   * --reporter=/absolute/path/to/reporter.js
+   * -R /absolute/path/to/reporter.js
+   * ```
+   */
+  public static getReporterScriptPath(argv: Array<string> = process.argv.slice(2)): string {
+    const reporterArgs = argv
+      .map((arg, index) => {
+        if ((index > 0 && argv[index - 1] === "--reporter") || argv[index - 1] === "-R") {
+          return arg.trim();
+        }
+        if (arg.startsWith("--reporter=")) {
+          return arg.substring(11).trim();
+        }
+        return undefined;
+      })
+      .filter((a) => a != null && a !== "");
+    if (reporterArgs.length !== 1) {
+      throw new ReferenceError(AsMochaReporter.CANNOT_FIND_ERROR);
+    }
+    return reporterArgs.at(0) as string;
+  }
+
+  /**
+   * Load the specified reporter.  Reporter scripts (or packages) should
+   * have a single default export, which is a function which accepts a
+   * mocha Runner as its only param/arg.
+   * @example
+   * For modern JS:
+   * ```javascript
+   * /\*\* \@param {import("mocha").Runner} runner \*\/
+   * const reporter = (runner) => { };
+   * export default reporter;
+   * ```
+   * Using `module.exports`:
+   * ```javascript
+   * /\*\* \@param {import("mocha").Runner} runner \*\/
+   * const reporter = (runner) => { };
+   * module.exports = reporter;
+   * ```
+   */
+  public static async loadReporter(options: LoadReporterOptions = {}): Promise<RunnerHandler> {
+    const reporterName = options.reporter ?? AsMochaReporter.getReporterScriptPath();
+    const reporterModule = (await import(reporterName)).default as unknown;
+    if (options.verbose) {
+      console.log(`Reporter loaded: ${reporterName}`);
+    }
+    if (typeof reporterModule !== "function") {
+      throw new Error(`Imported reporter does not have a default export: ${reporterName}`);
+    }
+    return reporterModule as RunnerHandler;
+  }
+
+  constructor(config: ResolvedConfig) {
+    super(config);
+    AsMochaReporter.loadReporter().then(() => {
+      console.log("Reporter loaded");
+    });
+  }
+
+  public override on([event, _payload]: ReporterEvent): void {
+    console.log(event);
+    // TODO
+  }
+}

--- a/source/AssertionError.ts
+++ b/source/AssertionError.ts
@@ -16,6 +16,7 @@ import type { Diagnostic } from "tstyche/tstyche";
  *   `expected` values.
  */
 export class AssertionError extends Error {
+  public override readonly name = "AssertionError";
   public override readonly stack: string;
   public readonly actualType: string;
   public readonly matcher: string;

--- a/test/AsMochaReporter.test.ts
+++ b/test/AsMochaReporter.test.ts
@@ -1,0 +1,65 @@
+import * as path from "node:path";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import AsMochaReporter from "../source/AsMochaReporter.js";
+
+const reporterPath = "path/to/reporter.js";
+
+describe("AsMochaReporter", () => {
+  describe("getReporterScriptPath", () => {
+    it("finds -R", () => {
+      expect(AsMochaReporter.getReporterScriptPath(["--ignored", "-R", reporterPath, "*.test.ts"])).eq(reporterPath);
+    });
+    it("finds --reporter", () => {
+      expect(AsMochaReporter.getReporterScriptPath(["--ignored", "--reporter", reporterPath, "*.test.ts"])).eq(
+        reporterPath,
+      );
+    });
+    it("finds --reporter=path", () => {
+      expect(AsMochaReporter.getReporterScriptPath(["--ignored", `--reporter=${reporterPath}`, "*.test.ts"])).eq(
+        reporterPath,
+      );
+    });
+    it("throws for missing -R value", () => {
+      expect(() => AsMochaReporter.getReporterScriptPath(["--ignored", "-R"])).throws(
+        ReferenceError,
+        AsMochaReporter.CANNOT_FIND_ERROR,
+      );
+    });
+    it("throws for missing --reporter value", () => {
+      expect(() => AsMochaReporter.getReporterScriptPath(["--ignored", "--reporter"])).throws(
+        ReferenceError,
+        AsMochaReporter.CANNOT_FIND_ERROR,
+      );
+    });
+    it("throws for missing --reporter=path value", () => {
+      expect(() => AsMochaReporter.getReporterScriptPath(["--ignored", "--reporter="])).throws(
+        ReferenceError,
+        AsMochaReporter.CANNOT_FIND_ERROR,
+      );
+    });
+    it("throws for too many reporters", () => {
+      expect(() =>
+        AsMochaReporter.getReporterScriptPath(["--ignored", "--reporter", reporterPath, "-R", reporterPath]),
+      ).throws(ReferenceError, AsMochaReporter.CANNOT_FIND_ERROR);
+    });
+  });
+  describe("loadReporter", () => {
+    it("can load from package name", async () => {
+      const loaded = await AsMochaReporter.loadReporter({ reporter: "mocha-reporter-gha" });
+      expect(loaded).is.a("function");
+    });
+    it("can load ESM from path", async () => {
+      const testReporterPath = path.resolve(import.meta.dirname, "test-reporter.mjs");
+      const loaded = await AsMochaReporter.loadReporter({ reporter: testReporterPath });
+      expect(loaded).is.a("function");
+      expect(loaded.name).eq("testReporter");
+    });
+    it("can load CJS from path", async () => {
+      const testReporterPath = path.resolve(import.meta.dirname, "test-reporter.cjs");
+      const loaded = await AsMochaReporter.loadReporter({ reporter: testReporterPath });
+      expect(loaded).is.a("function");
+      expect(loaded.name).eq("testReporter");
+    });
+  });
+});

--- a/test/AssertionError.test.ts
+++ b/test/AssertionError.test.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { AssertionError } from "../source/AssertionError.js";
+
+describe("AssertionError", () => {
+  it("has a reasonable stack trace", () => {
+    const message = "some message";
+    const actualType = "actualType";
+    const matcher = "matcher";
+    const expectedType = "expectedType";
+    const sourceLocation: string = "path/to/source.ts:12:34";
+    const error = new AssertionError(message, actualType, matcher, expectedType, [], sourceLocation);
+    expect(error.stack, "stack").to.match(
+      new RegExp(`^${error.name}: ${message}\\s+at ${matcher} \\(${sourceLocation}\\)\s*`),
+    );
+    expect(error.name, "name").eq("AssertionError");
+    expect(error.matcher, "matcher").eq(matcher);
+    expect(error.sourceLocation, "sourceLocation").eq(sourceLocation);
+    expect(error.actualType, "actualType").eq(actualType);
+    expect(error.expectedType, "expectedType").eq(expectedType);
+  });
+});

--- a/test/test-reporter.cjs
+++ b/test/test-reporter.cjs
@@ -1,0 +1,10 @@
+/**
+ * @param {import("mocha").Runner} runner
+ */
+const testReporter = (runner) => {
+  if (runner == null) {
+    throw new Error("Did not receive a mocha Runner");
+  }
+};
+
+module.exports = testReporter;

--- a/test/test-reporter.mjs
+++ b/test/test-reporter.mjs
@@ -1,0 +1,10 @@
+/**
+ * @param {import("mocha").Runner} runner
+ */
+const testReporter = (runner) => {
+  if (runner == null) {
+    throw new Error("Did not receive a mocha Runner");
+  }
+};
+
+export default testReporter;

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -6,6 +6,6 @@
     "outDir": "./build/cjs",
     "target": "ES2016"
   },
-  "include": ["./source/mocha.ts"],
+  "include": ["./source/**/*.ts"],
   "extends": "./tsconfig.json"
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -6,6 +6,6 @@
     "rootDir": "./source",
     "target": "ES2022"
   },
-  "include": ["./source/mocha.ts"],
+  "include": ["./source/**/*.ts"],
   "extends": "./tsconfig.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "preserveConstEnums": true,
     "removeComments": true,
     "rootDir": "./",
+    "sourceMap": true,
     "strict": true,
     "target": "es2022",
     "types": ["node"]

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -9,6 +9,6 @@
     "noEmit": false,
     "outDir": "./build/types"
   },
-  "include": ["./source/mocha.ts"],
+  "include": ["./source/**/*.ts"],
   "extends": "./tsconfig.json"
 }

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,0 +1,3 @@
+{
+  "testFileMatch": ["type-test/**/*.tst.ts"]
+}

--- a/type-test/AssertionError.tst.ts
+++ b/type-test/AssertionError.tst.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "tstyche";
+import type { AssertionError } from "../source/AssertionError.js";
+
+describe("AssertionError", () => {
+  it("is an Error", () => {
+    expect<AssertionError>().type.toBeAssignableTo<Error>();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,42 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@actions/core@npm:^1.10.1":
+  version: 1.11.1
+  resolution: "@actions/core@npm:1.11.1"
+  dependencies:
+    "@actions/exec": "npm:^1.1.1"
+    "@actions/http-client": "npm:^2.0.1"
+  checksum: 10c0/9aa30b397d8d0dbc74e69fe46b23fb105cab989beb420c57eacbfc51c6804abe8da0f46973ca9f639d532ea4c096d0f4d37da0223fbe94f304fa3c5f53537c30
+  languageName: node
+  linkType: hard
+
+"@actions/exec@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@actions/exec@npm:1.1.1"
+  dependencies:
+    "@actions/io": "npm:^1.0.1"
+  checksum: 10c0/4a09f6bdbe50ce68b5cf8a7254d176230d6a74bccf6ecc3857feee209a8c950ba9adec87cc5ecceb04110182d1c17117234e45557d72fde6229b7fd3a395322a
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^2.0.1":
+  version: 2.2.3
+  resolution: "@actions/http-client@npm:2.2.3"
+  dependencies:
+    tunnel: "npm:^0.0.6"
+    undici: "npm:^5.25.4"
+  checksum: 10c0/13141b66a42aa4afd8c50f7479e13a5cdb5084ccb3c73ec48894b8029743389a3d2bf8cdc18e23fb70cd33995740526dd308815613907571e897c3aa1e5eada6
+  languageName: node
+  linkType: hard
+
+"@actions/io@npm:^1.0.1":
+  version: 1.1.3
+  resolution: "@actions/io@npm:1.1.3"
+  checksum: 10c0/5b8751918e5bf0bebd923ba917fb1c0e294401e7ff0037f32c92a4efa4215550df1f6633c63fd4efb2bdaae8711e69b9e36925857db1f38935ff62a5c92ec29e
+  languageName: node
+  linkType: hard
+
 "@biomejs/biome@npm:1.9.4":
   version: 1.9.4
   resolution: "@biomejs/biome@npm:1.9.4"
@@ -628,6 +664,181 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/aix-ppc64@npm:0.23.1"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-arm64@npm:0.23.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-arm@npm:0.23.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-x64@npm:0.23.1"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/darwin-arm64@npm:0.23.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/darwin-x64@npm:0.23.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.23.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/freebsd-x64@npm:0.23.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-arm64@npm:0.23.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-arm@npm:0.23.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-ia32@npm:0.23.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-loong64@npm:0.23.1"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-mips64el@npm:0.23.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-ppc64@npm:0.23.1"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-riscv64@npm:0.23.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-s390x@npm:0.23.1"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-x64@npm:0.23.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/netbsd-x64@npm:0.23.1"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.23.1"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/openbsd-x64@npm:0.23.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/sunos-x64@npm:0.23.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-arm64@npm:0.23.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-ia32@npm:0.23.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-x64@npm:0.23.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@fastify/busboy@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@fastify/busboy@npm:2.1.1"
+  checksum: 10c0/6f8027a8cba7f8f7b736718b013f5a38c0476eea67034c94a0d3c375e2b114366ad4419e6a6fa7ffc2ef9c6d3e0435d76dd584a7a1cbac23962fda7650b579e3
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -677,6 +888,22 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10c0/5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:5.0.1":
+  version: 5.0.1
+  resolution: "@types/chai@npm:5.0.1"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+  checksum: 10c0/82cb718101d37698e35fb03e2a983a442303065bfcb9b9e8b50b49fdad2fa5759c14dabfa5cb4a4bfa5c6aff1f05377d6ab4310bae0cfbf7d3138f94c969f441
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
   languageName: node
   linkType: hard
 
@@ -771,6 +998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -820,6 +1054,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-from@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^19.0.1":
   version: 19.0.1
   resolution: "cacache@npm:19.0.1"
@@ -854,6 +1095,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:5.1.2":
+  version: 5.1.2
+  resolution: "chai@npm:5.1.2"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10c0/6c04ff8495b6e535df9c1b062b6b094828454e9a3c9493393e55b2f4dbff7aa2a29a4645133cad160fb00a16196c4dc03dc9bb37e1f4ba9df3b5f50d7533a736
+  languageName: node
+  linkType: hard
+
 "chalk-template@npm:^1.1.0":
   version: 1.1.0
   resolution: "chalk-template@npm:1.1.0"
@@ -877,6 +1131,13 @@ __metadata:
   version: 5.4.1
   resolution: "chalk@npm:5.4.1"
   checksum: 10c0/b23e88132c702f4855ca6d25cb5538b1114343e41472d5263ee8a37cccfccd9c4216d111e1097c6a27830407a1dc81fecdf2a56f2c63033d4dbbd88c10b0dcef
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "check-error@npm:2.1.1"
+  checksum: 10c0/979f13eccab306cf1785fa10941a590b4e7ea9916ea2a4f8c87f0316fc3eab07eabefb6e587424ef0f88cbcd3805791f172ea739863ca3d7ce2afc54641c7f0e
   languageName: node
   linkType: hard
 
@@ -1162,6 +1423,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
+  languageName: node
+  linkType: hard
+
 "diff@npm:^5.2.0":
   version: 5.2.0
   resolution: "diff@npm:5.2.0"
@@ -1217,6 +1485,89 @@ __metadata:
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
   checksum: 10c0/b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:~0.23.0":
+  version: 0.23.1
+  resolution: "esbuild@npm:0.23.1"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.23.1"
+    "@esbuild/android-arm": "npm:0.23.1"
+    "@esbuild/android-arm64": "npm:0.23.1"
+    "@esbuild/android-x64": "npm:0.23.1"
+    "@esbuild/darwin-arm64": "npm:0.23.1"
+    "@esbuild/darwin-x64": "npm:0.23.1"
+    "@esbuild/freebsd-arm64": "npm:0.23.1"
+    "@esbuild/freebsd-x64": "npm:0.23.1"
+    "@esbuild/linux-arm": "npm:0.23.1"
+    "@esbuild/linux-arm64": "npm:0.23.1"
+    "@esbuild/linux-ia32": "npm:0.23.1"
+    "@esbuild/linux-loong64": "npm:0.23.1"
+    "@esbuild/linux-mips64el": "npm:0.23.1"
+    "@esbuild/linux-ppc64": "npm:0.23.1"
+    "@esbuild/linux-riscv64": "npm:0.23.1"
+    "@esbuild/linux-s390x": "npm:0.23.1"
+    "@esbuild/linux-x64": "npm:0.23.1"
+    "@esbuild/netbsd-x64": "npm:0.23.1"
+    "@esbuild/openbsd-arm64": "npm:0.23.1"
+    "@esbuild/openbsd-x64": "npm:0.23.1"
+    "@esbuild/sunos-x64": "npm:0.23.1"
+    "@esbuild/win32-arm64": "npm:0.23.1"
+    "@esbuild/win32-ia32": "npm:0.23.1"
+    "@esbuild/win32-x64": "npm:0.23.1"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/08c2ed1105cc3c5e3a24a771e35532fe6089dd24a39c10097899072cef4a99f20860e41e9294e000d86380f353b04d8c50af482483d7f69f5208481cce61eec7
   languageName: node
   linkType: hard
 
@@ -1364,7 +1715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -1374,7 +1725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -1401,6 +1752,15 @@ __metadata:
   version: 9.0.0
   resolution: "get-stdin@npm:9.0.0"
   checksum: 10c0/7ef2edc0c81a0644ca9f051aad8a96ae9373d901485abafaabe59fd347a1c378689d8a3d8825fb3067415d1d09dfcaa43cb9b9516ecac6b74b3138b65a8ccc6b
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.8.1
+  resolution: "get-tsconfig@npm:4.8.1"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/536ee85d202f604f4b5fb6be81bcd6e6d9a96846811e83e9acc6de4a04fb49506edea0e1b8cf1d5ee7af33e469916ec2809d4c5445ab8ae015a7a51fbd1572f9
   languageName: node
   linkType: hard
 
@@ -1734,6 +2094,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "loupe@npm:3.1.2"
+  checksum: 10c0/b13c02e3ddd6a9d5f8bf84133b3242de556512d824dddeea71cce2dbd6579c8f4d672381c4e742d45cf4423d0701765b4a6e5fbc24701def16bc2b40f8daa96a
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
@@ -1914,6 +2281,15 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/e2e2be789218807b58abced04e7b49851d9e46e88a2f9539242cc8a92c9b5c3a0b9bab360bd3014e02a140fc4fbc58e31176c408b493f8a2a6f4986bd7527b01
+  languageName: node
+  linkType: hard
+
+"mocha-reporter-gha@npm:1.1.1":
+  version: 1.1.1
+  resolution: "mocha-reporter-gha@npm:1.1.1"
+  dependencies:
+    "@actions/core": "npm:^1.10.1"
+  checksum: 10c0/5c27279d0e44ae845beaf4bf43b75bd3dc9fefa454f133c819d6dd7f4f6bea28b4f241707770a460d39418ec82b2db2b5888fb49df6f02e627077a4e3894370b
   languageName: node
   linkType: hard
 
@@ -2100,6 +2476,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathval@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "pathval@npm:2.0.0"
+  checksum: 10c0/602e4ee347fba8a599115af2ccd8179836a63c925c23e04bd056d0674a64b39e3a081b643cc7bc0b84390517df2d800a46fcc5598d42c155fe4977095c2f77c5
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
@@ -2174,6 +2557,13 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 10c0/b21cb7f1fb746de8107b9febab60095187781137fd803e6a59a76d421444b1531b641bba5857f5dc011974d8a5c635d61cec49e6bd3b7fc20e01f0fafc4efbf2
+  languageName: node
+  linkType: hard
+
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
   languageName: node
   linkType: hard
 
@@ -2301,6 +2691,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:0.5.21":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: "npm:^1.0.0"
+    source-map: "npm:^0.6.0"
+  checksum: 10c0/9ee09942f415e0f721d6daad3917ec1516af746a8120bba7bb56278707a37f1eb8642bde456e98454b8a885023af81a16e646869975f06afc1a711fb90484e7d
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.6.0":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:^1.1.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
@@ -2420,14 +2827,19 @@ __metadata:
   resolution: "tstyche-as-mocha@workspace:."
   dependencies:
     "@biomejs/biome": "npm:1.9.4"
+    "@types/chai": "npm:5.0.1"
     "@types/mocha": "npm:10.0.10"
     "@types/node": "npm:22.10.5"
+    chai: "npm:5.1.2"
     cpr: "npm:3.0.1"
     cspell: "npm:8.17.1"
     mkdirp: "npm:3.0.1"
     mocha: "npm:11.0.1"
+    mocha-reporter-gha: "npm:1.1.1"
     rimraf: "npm:6.0.1"
+    source-map-support: "npm:0.5.21"
     tstyche: "npm:3.3.1"
+    tsx: "npm:4.19.2"
     typescript: "npm:5.7.2"
   bin:
     tstyche-as-mocha: ./source/mocha.ts
@@ -2445,6 +2857,29 @@ __metadata:
   bin:
     tstyche: ./build/bin.js
   checksum: 10c0/bbedbbf88b1e93ac8be119ed2c3436d27bbf6e7907e3d4b5018111d697f8c4c86b0ca5887828c111da708810ea861e7ab698e0a02374914ef3643e5e514dbc2b
+  languageName: node
+  linkType: hard
+
+"tsx@npm:4.19.2":
+  version: 4.19.2
+  resolution: "tsx@npm:4.19.2"
+  dependencies:
+    esbuild: "npm:~0.23.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/63164b889b1d170403e4d8753a6755dec371f220f5ce29a8e88f1f4d6085a784a12d8dc2ee669116611f2c72757ac9beaa3eea5c452796f541bdd2dc11753721
+  languageName: node
+  linkType: hard
+
+"tunnel@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "tunnel@npm:0.0.6"
+  checksum: 10c0/e27e7e896f2426c1c747325b5f54efebc1a004647d853fad892b46d64e37591ccd0b97439470795e5262b5c0748d22beb4489a04a0a448029636670bfd801b75
   languageName: node
   linkType: hard
 
@@ -2472,6 +2907,15 @@ __metadata:
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
   checksum: 10c0/68e659a98898d6a836a9a59e6adf14a5d799707f5ea629433e025ac90d239f75e408e2e5ff086afc3cace26f8b26ee52155293564593fbb4a2f666af57fc59bf
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.25.4":
+  version: 5.28.4
+  resolution: "undici@npm:5.28.4"
+  dependencies:
+    "@fastify/busboy": "npm:^2.0.0"
+  checksum: 10c0/08d0f2596553aa0a54ca6e8e9c7f45aef7d042c60918564e3a142d449eda165a80196f6ef19ea2ef2e6446959e293095d8e40af1236f0d67223b06afac5ecad7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This also includes the prototype for loading the runner via a script name instead of as a live object.  Seems to work!  This would mean we don't need to expose a `Runner.addReporter` function upstream.